### PR TITLE
소셜 로그인 username(이메일 필드)가 빈 문자열이면 회원가입 폼으로 이동

### DIFF
--- a/django_app/member/models/myuser.py
+++ b/django_app/member/models/myuser.py
@@ -11,39 +11,38 @@ from utils.fields import CustomImageField
 
 class MyUserManager(DefaultUserManager):
     def get_or_create_facebook_user(self, user_info):
-        username = user_info.get('email', '')
+        """ Facebook Custom UserManager """
+
+        # username = user_info.get('email', '')
         my_photo = user_info.get('picture', '')
         nickname = '{}_{}'.format(
             self.model.USER_TYPE_FACEBOOK,
             user_info['id']
         )
-        slug = '{}_{}'.format(
-            self.model.USER_TYPE_FACEBOOK,
-            user_info['id']
-        )
 
-        if username and self.model.objects.filter(slug=slug):
-            user = self.model.objects.get(slug=slug)
+        username = ''
+
+        if username and self.model.objects.filter(slug=nickname):
+            user = self.model.objects.get(slug=nickname)
         else:
             user = self.model.objects.create(
                 username=username,
                 user_type=self.model.USER_TYPE_FACEBOOK,
                 my_photo=my_photo['data']['url'],
                 nickname=nickname,
-                slug=slug
+                slug=nickname
             )
-
         return user
 
     def get_or_create_kakao_user(self, user_info):
+        """ Kakao Custom UserManager """
+
         username = user_info.get('kaccount_email', '')
         my_photo = user_info.get('properties', '')
         nickname = '{}_{}'.format(
             self.model.USER_TYPE_KAKAO,
             user_info['id']
         )
-
-        # username = ''
 
         if username and self.model.objects.filter(slug=nickname):
             user = self.model.objects.get(slug=nickname)

--- a/django_app/member/views/auth.py
+++ b/django_app/member/views/auth.py
@@ -39,7 +39,6 @@ def signup(request):
     slug = request.POST.get('slug')
 
     if request.method == "POST":
-
         if request.POST.get('user_type') == 'f':
             my_photo = request.POST.get('my_photo')
             social_photo = request.POST.get('social_photo')
@@ -77,7 +76,6 @@ def signup(request):
             user.save()
             return redirect('member:complete_signup')
     else:
-        # return redirect('member:check_basic_info')
         form = SignupForm()
         username = request.session['username']
         nickname = request.session['nickname']
@@ -135,6 +133,16 @@ def facebook_login(request):
         debug_result = facebook_debug_token(access_token)
         user_info = facebook_get_user_info(user_id=debug_result['data']['user_id'], access_token=access_token)
         user = MyUser.objects.get_or_create_facebook_user(user_info)
+
+        # email이 존재하지 않으면, 즉 username이 빈 문자열이면
+        if user.username == '':
+            context = {
+                'nickname': user.nickname,
+                'my_photo': str(user.my_photo),
+                'slug': user.slug,
+                'form': BasicInfoForm()
+            }
+            return render(request, 'member/input_basic_info.html', context)
 
         django_login(request, user)
         return redirect('book:main')


### PR DESCRIPTION
- 페이스북, 카카오 로그인시 email value가 존재하지 않으면 username에 빈 문자열 할당
- 데이터 베이스에 임의로 저장된 값에서 username이 빈 문자열일 경우, 회원가입 폼으로 이동하여 입력한 정보가 업데이트
- 하지만 앞서 저장한 값을 어떻게 같은 유저로 인식하고 다시 불러올 지에 대한 이슈가 발생한다.
- 가장 마지막 레코드의 pk를 호출하여 처리한다면 그 사이에 다른 유저가 가입했을 가능성이 존재하기 때문에 부적합
- 따라서 페이스북, 카카오에서 각각 발급받는 고유한 값인 id를 활용하여 nickname을 만들었던 점을 활용, 그러나 nickname은 사용자가 폼에서 바꿀 수 있도록 구성하였기 때문에 nickname으로 레코드의 정보를 부르는 것 또한 적절하지 않다.
- 결론적으로 slug라는 이름으로 새로운 필드를 생성하고, 고유값인 최초의 nickname 값을 slug 필드에 기입하여 slug 필드를 통해 대조하여 레코드를 불러오는 방식을 적용했다.

[고민] 일반 회원가입에서는 clean 메서드가 작용하여 validate가 되지만, 소셜 로그인시 form action="{% url 'member:signup' %}" 으로 인해 유효성 검사를 거치지 않는다.