### PR TITLE
일반 회원, 소셜 로그인 유저 이미지 커스텀 텔플릿 태그

### DIFF
--- a/django_app/book/templatetags/comment.py
+++ b/django_app/book/templatetags/comment.py
@@ -1,4 +1,3 @@
-import re
 from django import template
 
 register = template.Library()
@@ -12,13 +11,3 @@ def star(value):
 @register.filter
 def hide(value):
     return value.replace(value[4:], "*****")
-
-
-@register.filter
-def img_filter(value):
-    p = re.compile('ht{2}p')
-    rep = value.replace(value[:7], "")
-    m = p.search(rep)
-    if m:
-        return True
-    return False

--- a/django_app/book/templatetags/profile.py
+++ b/django_app/book/templatetags/profile.py
@@ -1,0 +1,16 @@
+import re
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def img_filter(value):
+    """ 일반, 소셜 회원 이미지 필터 """
+
+    p = re.compile('ht{2}p')
+    rep = value.replace(value[:7], "")
+    m = p.search(rep)
+    if m:
+        return True
+    return False

--- a/django_app/templates/book/sell_book_detail.html
+++ b/django_app/templates/book/sell_book_detail.html
@@ -92,6 +92,8 @@
 //            source: autocomplete_text
 //        });
 //    })
+
+    // 사용자 태그 자동 완성
     $(document).ready(function() {
       $("#autocomplete").keyup(function(e) {
         e.preventDefault();
@@ -99,8 +101,7 @@
         keywords = keywords.replace("@", "");
         if(keywords != "") {
           $.ajax({
-            // url: "http://usedbookstore-dev.ap-northeast-2.elasticbeanstalk.com/books/comment/autocomplete/" + keywords,
-            url: "http://localhost:8000/books/comment/autocomplete/" + keywords,
+            url: "http://usedbookstore-dev.ap-northeast-2.elasticbeanstalk.com/books/comment/autocomplete/" + keywords,
             type: "get",
             success: function(resp) {
               if(resp != "") {

--- a/django_app/templates/include/autocomplete.html
+++ b/django_app/templates/include/autocomplete.html
@@ -1,5 +1,5 @@
 {% load static %}
-{% load comment %}
+{% load profile %}
 
 <link rel="stylesheet" href="{% static 'css/book-register.css' %}">
 <ul class="autocomplete-box">

--- a/django_app/templates/include/side-nav.html
+++ b/django_app/templates/include/side-nav.html
@@ -1,3 +1,5 @@
+{% load profile %}
+
 <!-- 사이드 메뉴바 -->
 <div id="mySidenav" class="sidenav">
   <a href="javascript:void(0)" class="closebtn" onclick="closeNav()">&times;</a>
@@ -5,10 +7,10 @@
   {% if user.is_authenticated %}
     <ul class="my-info">
       <li class="my-photo">
-        {% if user.slug %}
-          <img src="{{ user.my_photo }}" alt="">
+        {% if user.my_photo.url|img_filter %}
+          <img src="{{ user.my_photo}}">
         {% else %}
-          <img src="{{ user.my_photo.url }}">
+          <img src="{{ user.my_photo.url}}">
         {% endif %}
       </li>
       <li class="my-page">


### PR DESCRIPTION
[이미지 필터]
- 소셜 로그인의 경우 사용자 프로필 이미지를 보이려면 해당 사이트의 서버에 올려진 이미지 url 주소로 접근해야한다.
- MyUser 모델에 user_type 필드가 있고, 일반 회원가입 회원이면 'd', 소셜 로그인 회원이면 'f', 'k'로 저장되어 user_type을 기준으로 템플릿에서 {{ 유저객체.이미지필드.url }}의 url 여부를 결정할 수 있다.
- 하지만 소셜 로그인일지라도 사용자가 프로필 사진을 업데이트 할 수 있기 때문에 이 방식으로 분류하는 것은 적절하지 못 하다.
- 따라서 커스텀 템플릿 태그를 활용하였다. 서버에 올리진 이미지(소셜 로그인 이미지)의 경우 'http'로 시작하므로 정규표현식 'ht{2}p'에 매칭되면 True, 아니면 False를 반환하는 필터를 작성하였다.
- 템플릿에서 {% if user.my_photo.url|img_filter %} 가 True면 {{ user.my_photo }}, False면 {{ user.my_photo.url }}을 보여준다.

[검색어에 따른 자동 완성 기능]
- autocomplete 뷰에서 keyword 인자를 get 요청으로 받아서 해당 키워드가 nickname에 포함되면 해당 유저 객체를 반환한다.
- 템플릿(sell_book_detail.html)에서 AJAX 통신을 통하여 비동기로 정보를 호출하는 방식이다.

[고민] 자동 완성 기능에 대한 더 좋은 방법으로 어떤 것이 있을까? 
